### PR TITLE
fix non-full buffers not being written into disk

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -57,6 +57,8 @@ include: "rules/chanlist_gen.smk"
 include: "rules/common.smk"
 include: "rules/main.smk"
 include: "rules/tcm.smk"
+
+
 # include: "rules/dsp_pars_geds.smk"
 # include: "rules/dsp_pars_spms.smk"
 # include: "rules/dsp.smk"

--- a/workflow/Snakefile-build-raw
+++ b/workflow/Snakefile-build-raw
@@ -29,8 +29,8 @@ time = datetime.now().strftime("%Y%m%dT%H%M%SZ")
 
 # Had to disable this since it tried to sync legend-metadata even though dir was existing
 # NOTE: this will attempt a clone of legend-metadata, if the directory does not exist
-#metadata = LegendMetadata(meta_path, lazy=True)
-#if "legend_metadata_version" in config:
+# metadata = LegendMetadata(meta_path, lazy=True)
+# if "legend_metadata_version" in config:
 #    metadata.checkout(config.legend_metadata_version)
 
 

--- a/workflow/rules/filelist_gen.smk
+++ b/workflow/rules/filelist_gen.smk
@@ -163,7 +163,10 @@ def build_filelist(
         ignore_keys = []
     if analysis_runs is None:
         analysis_runs = {}
-    ignore_suffixes = [".log", ".mac"] # allows to store DAQ logs & macros together with the binary outputs
+    ignore_suffixes = [
+        ".log",
+        ".mac",
+    ]  # allows to store DAQ logs & macros together with the binary outputs
 
     phy_filenames = []
     other_filenames = []

--- a/workflow/src/legenddataflow/scripts/filedb.py
+++ b/workflow/src/legenddataflow/scripts/filedb.py
@@ -2,9 +2,7 @@ import argparse
 import logging
 from pathlib import Path
 
-import numpy as np
 from dbetto.catalog import Props
-from lgdo import lh5
 from pygama.flow.file_db import FileDB
 
 

--- a/workflow/src/legenddataflow/scripts/tier/raw_mgdo.py
+++ b/workflow/src/legenddataflow/scripts/tier/raw_mgdo.py
@@ -141,7 +141,10 @@ def build_tier_raw_mgdo() -> None:
             if tbl.is_full():
                 store.write(tbl, tbl_name, args.output, wo_mode="append")
                 tbl.clear()
-
+        # write the remaining table entries when the buffer is not completely filled
+        if tbl.loc != 0:
+            store.write(tbl, tbl_name, args.output, wo_mode="append", n_rows=tbl.loc)
+            tbl.clear()
 
 def _tblid(id):
     return f"ch{id:03d}/raw"

--- a/workflow/src/legenddataflow/scripts/tier/raw_mgdo.py
+++ b/workflow/src/legenddataflow/scripts/tier/raw_mgdo.py
@@ -146,6 +146,7 @@ def build_tier_raw_mgdo() -> None:
             store.write(tbl, tbl_name, args.output, wo_mode="append", n_rows=tbl.loc)
             tbl.clear()
 
+
 def _tblid(id):
     return f"ch{id:03d}/raw"
 


### PR DESCRIPTION
Non-full table buffers in the raw_mgdo.py are currently not being written into disk.